### PR TITLE
refactor: add cfg_aliases

### DIFF
--- a/book/src/test-declaration.md
+++ b/book/src/test-declaration.md
@@ -1,10 +1,10 @@
 # Test declaration
 
-Test cases have the same structure than usual Rust tests, 
+Test cases have the same structure than usual Rust tests,
 that is `unwrap`ing `Result`s and using assertion macros (`assert` and `assert_eq`),
 the exception being that it should take a `&mut TestContext` parameter.
 It might also take a `FileType` argument if required.
-It also needs an additional declaration with the `test_case!` macro alongside the function, 
+It also needs an additional declaration with the `test_case!` macro alongside the function,
 with the function name being the only mandatory argument.
 
 For example:
@@ -25,23 +25,33 @@ fn ctime(ctx: &mut TestContext, f_type: FileType) {
 }
 ```
 
+All the structures and functions needed are documented in the `pjdfstest` crate,
+which you can obtain by running `cargo doc --open` in the `rust` directory
+or by visiting the [online documentation](/doc/pjdfstest).
+
 ## Test context
 
-The `TestContext` struct is a helper struct which provides methods to create files, sleep, change user, etc.
-It is passed as a parameter to the test functions and should be used to interact with the system in order to
-ensure that the tests are isolated and do not interfere with each other.
+The `TestContext` struct is a helper struct which provides methods
+to create files, sleep, change user, etc.
+It is passed as a parameter to the test functions and should be used
+to interact with the system in order to ensure that the tests are isolated
+and do not interfere with each other.
 
 ### Serialization
 
 When a test case needs to be run in a serialized manner, the `SerializedTestContext` struct should be used instead.
 It provides additional methods to change the user, group, supplementary groups, or umask of the process.
+Please see the [Serialized test cases](#serialized-test-cases) section for more information.
 
 ## Assertions
 
 The `assert` and `assert_eq` macros should be used to check the results of the tests.
-The `assert` macro should be used when the test is checking a condition, while the `assert_eq` macro should be used when the test is checking that two values are equal.
-In addition to these macros, the suite provides some additional assertion macros which should be used when appropriate.
-`assert_ctime_changed` should be used when checking that the ctime of a file has changed, and `assert_mtime_changed` should be used when checking that the mtime of a file has changed.
+The `assert` macro should be used when the test is checking a condition,
+while the `assert_eq` macro should be used when the test is checking that two values are equal.
+In addition to these macros, the suite provides some additional assertion macros which
+should be used when appropriate.
+`assert_ctime_changed` should be used when checking that the ctime of a file has changed,
+and `assert_mtime_changed` should be used when checking that the mtime of a file has changed.
 
 ## Description
 
@@ -110,7 +120,7 @@ pub type Guard = fn(&Config, &Path) -> anyhow::Result<()>;
 fn has_reasonable_link_max(_: &Config, base_path: &Path) -> anyhow::Result<()> {
     let link_max = pathconf(base_path, nix::unistd::PathconfVar::LINK_MAX)?
         .ok_or_else(|| anyhow::anyhow!("Failed to get LINK_MAX value"))?;
-    
+
     if link_max >= LINK_MAX_LIMIT {
         anyhow::bail!("LINK_MAX value is too high ({link_max}, expected smaller than {LINK_MAX_LIMIT}");
     }
@@ -128,7 +138,7 @@ crate::test_case! {
 ### Root privileges
 
 Some tests may need root privileges to run.
-To declare that a test function require such privileges, 
+To declare that a test function require such privileges,
 `root` should be added to its declaration.
 For example:
 
@@ -149,12 +159,12 @@ The test function should also accept a `FileType` parameter to operate on.
 For example:
 
 ```rust,ignore
-crate::test_case! {change_perm, root, FileSystemFeature::Chflags; FileFlags::SF_IMMUTABLE, FileFlags::UF_IMMUTABLE 
+crate::test_case! {change_perm, root, FileSystemFeature::Chflags; FileFlags::SF_IMMUTABLE, FileFlags::UF_IMMUTABLE
 => [Regular, Fifo, Block, Char, Socket]}
 fn change_perm(ctx: &mut TestContext, f_type: FileType) {
 ```
 
-## Platform-specific features 
+## Platform-specific features
 
 Some features (like `lchmod`) are not supported on every operating system.
 When a test make use of such feature, it is possible to restrain its compilation
@@ -167,7 +177,9 @@ For example:
 mod lchmod;
 ```
 
-To declare it, the feature and its requirements have to be specified in the `build.rs` file using the usual conditional compilation [syntax](https://doc.rust-lang.org/reference/conditional-compilation.html).
+To declare it, the feature and its requirements have to be specified in the `build.rs` file
+using the usual conditional compilation
+[syntax](https://doc.rust-lang.org/reference/conditional-compilation.html).
 Then, the feature should be added to the `cfg_aliases!` macro.
 With `lchmod`, we would get:
 
@@ -181,7 +193,8 @@ With `lchmod`, we would get:
 
 ## Serialized test cases
 
-Some test cases need functions only available when they are run serialized, especially when they affect the whole process.
+Some test cases need functions only available when they are run serialized,
+especially when they affect the whole process.
 An example is changing user (`SerializedTestContext::as_user`).
 To have access to these functions, the test should be declared with a `SerializedTestContext`
 parameter in place of `TestContext` and the `serialized` keyword should be prepended before features.

--- a/book/src/tests-structure.md
+++ b/book/src/tests-structure.md
@@ -33,9 +33,9 @@ TC2 --> TC2F2[Test case]
 src/tests
 ├── chmod (syscall)
 │   ├── errno.rs (aspect)
-│   ├── mod.rs (syscall declaration)
 │   └── permission.rs (aspect)
 └── mod.rs (glues syscalls together)
+└── chmod.rs (syscall declaration)
 ```
 
 #### tests/mod.rs
@@ -49,8 +49,8 @@ pub mod chmod;
 ## Syscall module
 
 A syscall module contains test cases related to a specific syscall.
-Its declaration should be in the `mod.rs` file 
-of the relevant folder (`chmod/` in our case).
+Its declaration should be in the `<syscall_name>.rs` file at the root of the
+`tests/` directory.
 Common syscall-specific helpers can go here.
 
 ### Aspect
@@ -61,7 +61,7 @@ Here "aspect" is a subjective area of related functionality.
 The aspect module may be either:
 
 - in a single file, which contains all the test functions,
-- in a folder, which contains multiple modules for the test functions and a `mod.rs` file, in which the case is declared.
+- in a folder, which contains multiple modules for the test functions, in which the case is declared.
 
 Except in the case of a very large set of test functions, the first style
 should be preferred.

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -67,6 +67,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
 name = "ctor"
 version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -291,6 +297,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "caps",
+ "cfg_aliases",
  "exacl",
  "figment",
  "gumdrop",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -28,3 +28,6 @@ caps = "0.5.4"
 [[bin]]
 name = "pjdfstest"
 path = "src/main.rs"
+
+[build-dependencies]
+cfg_aliases = "0.2.1"

--- a/rust/build.rs
+++ b/rust/build.rs
@@ -1,0 +1,16 @@
+use cfg_aliases::cfg_aliases;
+
+fn main() {
+    // Setup cfg aliases
+    cfg_aliases! {
+        // OS-exclusive syscalls
+        chflags: { any(target_os = "openbsd", target_os = "netbsd", target_os = "freebsd", target_os = "dragonfly", target_os = "macos", target_os = "ios") },
+        lchmod: { any(target_os = "netbsd", target_os = "freebsd", target_os = "dragonfly") },
+        lchflags: { any(target_os = "openbsd", target_os = "netbsd", target_os = "freebsd",
+                    target_os = "dragonfly", target_os = "macos", target_os = "ios") },
+        // OS-exclusive features
+        file_flags: { any(target_os = "openbsd", target_os = "netbsd", target_os = "freebsd",
+                    target_os = "dragonfly", target_os = "macos", target_os = "ios") },
+        birthtime: { any(target_os = "freebsd", target_os = "ios", target_os = "macos", target_os = "netbsd", target_os = "openbsd") }
+    }
+}

--- a/rust/build.rs
+++ b/rust/build.rs
@@ -4,7 +4,7 @@ fn main() {
     // Setup cfg aliases
     cfg_aliases! {
         // OS-exclusive syscalls
-        chflags: { any(target_os = "openbsd", target_os = "netbsd", target_os = "freebsd", target_os = "dragonfly", target_os = "macos", target_os = "ios") },
+        chflags: { file_flags },
         lchmod: { any(target_os = "netbsd", target_os = "freebsd", target_os = "dragonfly") },
         lchflags: { any(target_os = "openbsd", target_os = "netbsd", target_os = "freebsd",
                     target_os = "dragonfly", target_os = "macos", target_os = "ios") },

--- a/rust/src/context.rs
+++ b/rust/src/context.rs
@@ -78,7 +78,7 @@ pub struct TestContext<'a> {
     features_config: &'a FeaturesConfig,
     auth_entries: DummyAuthEntries<'a>,
     #[cfg(target_os = "freebsd")]
-    jail: Option<jail::RunningJail>
+    jail: Option<jail::RunningJail>,
 }
 
 pub struct SerializedTestContext<'a> {
@@ -171,7 +171,7 @@ impl<'a> TestContext<'a> {
             features_config: &config.features,
             auth_entries: DummyAuthEntries::new(entries),
             #[cfg(target_os = "freebsd")]
-            jail: None
+            jail: None,
         }
     }
 
@@ -303,15 +303,7 @@ impl<'a> Drop for TestContext<'a> {
                 _ => continue,
             };
 
-            if cfg!(any(
-                target_os = "openbsd",
-                target_os = "netbsd",
-                target_os = "freebsd",
-                target_os = "dragonfly",
-                target_os = "macos",
-                target_os = "ios"
-            )) || entry.file_type().is_dir()
-            {
+            if cfg!(lchflags) || entry.file_type().is_dir() {
                 let file_stat = match lstat(entry.path()) {
                     Ok(s) => s,
                     _ => continue,
@@ -324,14 +316,7 @@ impl<'a> Drop for TestContext<'a> {
 
                 // We remove all flags
                 // TODO: Some platforms do not support lchflags, write chflagsat alternative for those (openbsd, macos, ios?)
-                #[cfg(any(
-                    target_os = "openbsd",
-                    target_os = "netbsd",
-                    target_os = "freebsd",
-                    target_os = "dragonfly",
-                    target_os = "macos",
-                    target_os = "ios"
-                ))]
+                #[cfg(lchflags)]
                 {
                     use crate::utils::lchflags;
                     use nix::{libc::fflags_t, sys::stat::FileFlag};
@@ -415,7 +400,7 @@ impl FileBuilder {
                     &path,
                 )?;
 
-                #[cfg(any(target_os = "netbsd", target_os = "freebsd", target_os = "dragonfly"))]
+                #[cfg(lchmod)]
                 if let Some(mode) = self.mode {
                     lchmod(&path, mode)?;
                 }

--- a/rust/src/flags.rs
+++ b/rust/src/flags.rs
@@ -9,15 +9,7 @@ macro_rules! flags {
                 $flag),*
         }
 
-        #[cfg(any(
-            target_os = "openbsd",
-            target_os = "netbsd",
-            target_os = "freebsd",
-            target_os = "dragonfly",
-            target_os = "macos",
-            target_os = "ios",
-            target_os = "watchos",
-        ))]
+        #[cfg(file_flags)]
         impl From<$enum> for nix::sys::stat::FileFlag {
             fn from(flag: $enum) -> Self {
                 match flag {

--- a/rust/src/tests/chmod.rs
+++ b/rust/src/tests/chmod.rs
@@ -5,7 +5,7 @@ use crate::{
     utils::{chmod, ALLPERMS},
 };
 
-#[cfg(any(target_os = "netbsd", target_os = "freebsd", target_os = "dragonfly"))]
+#[cfg(lchmod)]
 use crate::utils::lchmod;
 
 use nix::{
@@ -194,7 +194,7 @@ fn eftype(ctx: &mut SerializedTestContext, ft: FileType) {
     assert_eq!(file_stat.st_mode & ALLPERMS_STICKY, original_mode.bits());
 }
 
-#[cfg(any(target_os = "netbsd", target_os = "freebsd", target_os = "dragonfly"))]
+#[cfg(lchmod)]
 mod lchmod {
     use super::*;
 

--- a/rust/src/tests/mod.rs
+++ b/rust/src/tests/mod.rs
@@ -4,26 +4,11 @@ use std::os::unix::fs::MetadataExt as StdMetadataExt;
 
 use std::{fs::metadata, path::Path};
 
-#[cfg(any(
-    target_os = "freebsd",
-    target_os = "ios",
-    target_os = "macos",
-    target_os = "netbsd",
-    target_os = "openbsd"
-))]
-use nix::sys::stat::stat;
 use nix::sys::time::TimeSpec;
 
 use crate::test::TestContext;
 
-#[cfg(any(
-    target_os = "openbsd",
-    target_os = "netbsd",
-    target_os = "freebsd",
-    target_os = "dragonfly",
-    target_os = "macos",
-    target_os = "ios",
-))]
+#[cfg(chflags)]
 pub mod chflags;
 pub mod chmod;
 pub mod chown;
@@ -134,16 +119,12 @@ impl AsTimeInvariant for nix::sys::stat::FileStat {
     }
 }
 
-#[cfg(any(
-    target_os = "freebsd",
-    target_os = "ios",
-    target_os = "macos",
-    target_os = "netbsd",
-    target_os = "openbsd"
-))]
+#[cfg(birthtime)]
 // Note: can't be a method of MetadataExt, because StdMetadataExt lacks a
 // birthtime() method.
 fn birthtime_ts(path: &Path) -> TimeSpec {
+    use nix::sys::stat::stat;
+
     let sb = stat(path).unwrap();
     TimeSpec::new(sb.st_birthtime, sb.st_birthtime_nsec)
 }

--- a/rust/src/tests/utimensat.rs
+++ b/rust/src/tests/utimensat.rs
@@ -3,13 +3,7 @@ use std::{
     os::unix::fs::symlink,
 };
 
-#[cfg(any(
-    target_os = "freebsd",
-    target_os = "ios",
-    target_os = "macos",
-    target_os = "netbsd",
-    target_os = "openbsd"
-))]
+#[cfg(birthtime)]
 use crate::tests::birthtime_ts;
 use crate::tests::MetadataExt;
 use crate::utils::chmod;
@@ -99,25 +93,13 @@ fn utime_omit(ctx: &mut TestContext) {
     assert_eq!(md.mtime_ts(), date2);
 }
 
-#[cfg(any(
-    target_os = "freebsd",
-    target_os = "ios",
-    target_os = "macos",
-    target_os = "netbsd",
-    target_os = "openbsd"
-))]
+#[cfg(birthtime)]
 crate::test_case! {
     /// utimensat can update birthtimes
     // utimensat/03.t
     birthtime, FileSystemFeature::Utimensat, FileSystemFeature::StatStBirthtime
 }
-#[cfg(any(
-    target_os = "freebsd",
-    target_os = "ios",
-    target_os = "macos",
-    target_os = "netbsd",
-    target_os = "openbsd"
-))]
+#[cfg(birthtime)]
 fn birthtime(ctx: &mut TestContext) {
     let date1 = TimeSpec::seconds(100000000); // Sat Mar  3 02:46:40 MST 1973
     let date2 = TimeSpec::seconds(200000000); // Mon May  3 13:33:20 MDT 1976

--- a/rust/src/utils.rs
+++ b/rust/src/utils.rs
@@ -73,7 +73,7 @@ pub fn get_mountpoint(base_path: &Path) -> Result<&Path, anyhow::Error> {
 }
 
 /// Safe wrapper for `lchflags`.
-#[cfg(any(target_os = "netbsd", target_os = "freebsd", target_os = "dragonfly"))]
+#[cfg(lchflags)]
 pub fn lchflags<P: ?Sized + nix::NixPath>(
     path: &P,
     flags: nix::sys::stat::FileFlag,


### PR DESCRIPTION
Add support for cfg_aliases, to use aliases instead of long chains of conditions.
